### PR TITLE
Aggregate function aliases fix

### DIFF
--- a/udf-macros/Cargo.toml
+++ b/udf-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "udf-macros"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2021"
 description = "UDF procedural macros implementation"
 repository = "https://github.com/pluots/sql-udf/tree/main/udf_macros"

--- a/udf-macros/src/register.rs
+++ b/udf-macros/src/register.rs
@@ -280,7 +280,6 @@ fn make_agg_fns(
         .filter_map(match_variant!(ImplItem::Fn))
         .map(|m| &m.sig.ident)
         .any(|id| *id == "remove");
-    let base_fn_ident = Ident::new(base_fn_name, Span::call_site());
 
     let clear_fn = make_clear_fn(dstruct_path, wrapper_ident, &clear_fn_name);
     let add_fn = make_add_fn(dstruct_path, wrapper_ident, &add_fn_name);
@@ -295,10 +294,6 @@ fn make_agg_fns(
     };
 
     quote! {
-        // Sanity check that we implemented
-        #[allow(dead_code, non_upper_case_globals)]
-        const did_you_apply_the_same_aliases_to_the_BasicUdf_impl: *const () = #base_fn_ident as _;
-
         #clear_fn
 
         #add_fn


### PR DESCRIPTION
These strings are useless, they cause an error when they shouldn't, making it impossible to set aliases for agrig functions.

![image](https://github.com/pluots/sql-udf/assets/1196537/5c4f2be3-569a-4fa2-bc75-e9d8a9d1c092)
![image](https://github.com/pluots/sql-udf/assets/1196537/8c9dc778-c414-4f45-8a4b-0a94f132f460)
