### PR TITLE
Rework validation of names and aliases for aggregate UDFs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,22 +4,9 @@
 
 ## [Unreleased] - ReleaseDate
 
-### Added
-
-### Changed
-
-### Removed
-
-
-
-## [0.5.4] - 2023-09-10
-
-### Added
-
-### Changed
-
-### Removed
-
+Rework the validation of names and aliases for aggregate UDFs. This fixes an
+issue where aliases could not be used for aggregate UDFs, and provides better
+error messages.
 
 
 ## [0.5.4] - 2023-09-10

--- a/udf-macros/tests/fail/agg_missing_basic.rs
+++ b/udf-macros/tests/fail/agg_missing_basic.rs
@@ -1,0 +1,22 @@
+#![allow(unused)]
+
+use udf::prelude::*;
+
+struct MyUdf;
+
+impl AggregateUdf for MyUdf {
+    // Required methods
+    fn clear(&mut self, cfg: &UdfCfg<Process>, error: Option<NonZeroU8>) -> Result<(), NonZeroU8> {
+        todo!()
+    }
+    fn add(
+        &mut self,
+        cfg: &UdfCfg<Process>,
+        args: &ArgList<'_, Process>,
+        error: Option<NonZeroU8>,
+    ) -> Result<(), NonZeroU8> {
+        todo!()
+    }
+}
+
+fn main() {}

--- a/udf-macros/tests/fail/agg_missing_basic.stderr
+++ b/udf-macros/tests/fail/agg_missing_basic.stderr
@@ -1,0 +1,11 @@
+error[E0277]: the trait bound `MyUdf: BasicUdf` is not satisfied
+ --> tests/fail/agg_missing_basic.rs:7:23
+  |
+7 | impl AggregateUdf for MyUdf {
+  |                       ^^^^^ the trait `BasicUdf` is not implemented for `MyUdf`
+  |
+note: required by a bound in `udf::AggregateUdf`
+ --> $WORKSPACE/udf/src/traits.rs
+  |
+  | pub trait AggregateUdf: BasicUdf {
+  |                         ^^^^^^^^ required by this bound in `AggregateUdf`

--- a/udf-macros/tests/fail/missing_rename.stderr
+++ b/udf-macros/tests/fail/missing_rename.stderr
@@ -1,7 +1,22 @@
-error[E0425]: cannot find value `my_udf` in this scope
+error[E0080]: evaluation of constant value failed
+  --> $WORKSPACE/udf/src/wrapper.rs
+   |
+   |     panic!("{}", msg);
+   |     ^^^^^^^^^^^^^^^^^ the evaluated program panicked at '`#[register]` on `BasicUdf` and `AggregateUdf` must have the same `name` argument; got `foo` and `my_udf` (default from struct name)', $WORKSPACE/udf/src/wrapper.rs:83:5
+   |
+note: inside `wrapper::verify_aggregate_attributes_name::<MyUdf>`
+  --> $WORKSPACE/udf/src/wrapper.rs
+   |
+   |     panic!("{}", msg);
+   |     ^^^^^^^^^^^^^^^^^
+note: inside `verify_aggregate_attributes::<MyUdf>`
+  --> $WORKSPACE/udf/src/wrapper.rs
+   |
+   |     verify_aggregate_attributes_name::<T>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: inside `_`
   --> tests/fail/missing_rename.rs:25:1
    |
 25 | #[register]
-   | ^^^^^^^^^^^ not found in this scope
-   |
-   = note: this error originates in the attribute macro `register` (in Nightly builds, run with -Z macro-backtrace for more info)
+   | ^^^^^^^^^^^
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the attribute macro `register` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/udf-macros/tests/ok_agg_alias.rs
+++ b/udf-macros/tests/ok_agg_alias.rs
@@ -1,0 +1,51 @@
+#![allow(unused)]
+
+use udf::prelude::*;
+
+struct MyUdf;
+
+#[register(name = "foo", alias = "bar")]
+impl BasicUdf for MyUdf {
+    type Returns<'a> = Option<i64>;
+
+    fn init(cfg: &UdfCfg<Init>, args: &ArgList<Init>) -> Result<Self, String> {
+        todo!();
+    }
+
+    fn process<'a>(
+        &'a mut self,
+        cfg: &UdfCfg<Process>,
+        args: &ArgList<Process>,
+        error: Option<NonZeroU8>,
+    ) -> Result<Self::Returns<'a>, ProcessError> {
+        todo!();
+    }
+}
+
+#[register(name = "foo", alias = "bar")]
+impl AggregateUdf for MyUdf {
+    fn clear(&mut self, cfg: &UdfCfg<Process>, error: Option<NonZeroU8>) -> Result<(), NonZeroU8> {
+        todo!()
+    }
+    fn add(
+        &mut self,
+        cfg: &UdfCfg<Process>,
+        args: &ArgList<'_, Process>,
+        error: Option<NonZeroU8>,
+    ) -> Result<(), NonZeroU8> {
+        todo!()
+    }
+}
+
+fn main() {
+    let _ = foo as *const ();
+    let _ = foo_init as *const ();
+    let _ = foo_deinit as *const ();
+    let _ = foo_add as *const ();
+    let _ = foo_clear as *const ();
+    let _ = bar as *const ();
+    let _ = bar_init as *const ();
+    let _ = bar_deinit as *const ();
+    let _ = bar_add as *const ();
+    let _ = bar_clear as *const ();
+}

--- a/udf/src/types/arg_list.rs
+++ b/udf/src/types/arg_list.rs
@@ -19,7 +19,7 @@ use crate::{Init, SqlArg, UdfState};
 #[repr(transparent)]
 pub struct ArgList<'a, S: UdfState>(
     /// `UnsafeCell` indicates to the compiler that this struct may have interior
-    /// mutability (i.e., cannot make som optimizations)
+    /// mutability (i.e., cannot make some optimizations)
     pub(super) UnsafeCell<UDF_ARGSx>,
     /// We use this zero-sized marker to hold our state
     PhantomData<&'a S>,

--- a/udf/src/types/sql_types.rs
+++ b/udf/src/types/sql_types.rs
@@ -149,7 +149,7 @@ impl<'a> SqlResult<'a> {
         ptr: *const u8,
         tag: Item_result,
         len: usize,
-    ) -> Result<SqlResult<'a>, String> {
+    ) -> Result<Self, String> {
         // Handle nullptr right away here
 
         let marker =

--- a/udf/src/wrapper.rs
+++ b/udf/src/wrapper.rs
@@ -3,11 +3,16 @@
 //! Warning: This module should be considered unstable and generally not for
 //! public use
 
+#[macro_use]
+mod const_helpers;
 mod functions;
 mod helpers;
 mod modded_types;
 mod process;
 
+use std::str;
+
+use const_helpers::{const_slice_eq, const_slice_to_str, const_str_eq};
 pub use functions::{wrap_add, wrap_clear, wrap_deinit, wrap_init, wrap_remove, BufConverter};
 pub(crate) use helpers::*;
 pub use modded_types::UDF_ARGSx;
@@ -15,6 +20,108 @@ pub use process::{
     wrap_process_basic, wrap_process_basic_option, wrap_process_buf, wrap_process_buf_option,
     wrap_process_buf_option_ref,
 };
+
+/// A trait implemented by the proc macro
+// FIXME: on unimplemented
+pub trait RegisteredBasicUdf {
+    /// The main function name
+    const NAME: &'static str;
+    /// Aliases, if any
+    const ALIASES: &'static [&'static str];
+    /// True if `NAME` comes from the default value for the struct
+    const DEFAULT_NAME_USED: bool;
+}
+
+/// Implemented by the proc macro. This is used to enforce that the basic UDF and aggregate
+/// UDF have the same name and aliases.
+pub trait RegisteredAggregateUdf: RegisteredBasicUdf {
+    /// The main function name
+    const NAME: &'static str;
+    /// Aliases, if any
+    const ALIASES: &'static [&'static str];
+    /// True if `NAME` comes from the default value for the struct
+    const DEFAULT_NAME_USED: bool;
+}
+
+const NAME_MSG: &str = "`#[register]` on `BasicUdf` and `AggregateUdf` must have the same ";
+
+/// Enforce that a struct has the same basic and aggregate UDF names.
+pub const fn verify_aggregate_attributes<T: RegisteredAggregateUdf>() {
+    verify_aggregate_attributes_name::<T>();
+    verify_aggregate_attribute_aliases::<T>();
+}
+
+const fn verify_aggregate_attributes_name<T: RegisteredAggregateUdf>() {
+    let basic_name = <T as RegisteredBasicUdf>::NAME;
+    let agg_name = <T as RegisteredAggregateUdf>::NAME;
+    let basic_default_name = <T as RegisteredBasicUdf>::DEFAULT_NAME_USED;
+    let agg_default_name = <T as RegisteredAggregateUdf>::DEFAULT_NAME_USED;
+
+    if const_str_eq(basic_name, agg_name) {
+        return;
+    }
+
+    let mut msg_buf = [0u8; 512];
+    let mut curs = 0;
+    curs += const_write_all!(
+        msg_buf,
+        [NAME_MSG, "`name` argument; got `", basic_name, "`",],
+        curs
+    );
+
+    if basic_default_name {
+        curs += const_write_all!(msg_buf, [" (default from struct name)"], curs);
+    }
+
+    curs += const_write_all!(msg_buf, [" and `", agg_name, "`"], curs);
+
+    if agg_default_name {
+        curs += const_write_all!(msg_buf, [" (default from struct name)"], curs);
+    }
+
+    let msg = const_slice_to_str(msg_buf.as_slice(), curs);
+    panic!("{}", msg);
+}
+
+#[allow(clippy::cognitive_complexity)]
+const fn verify_aggregate_attribute_aliases<T: RegisteredAggregateUdf>() {
+    let basic_aliases = <T as RegisteredBasicUdf>::ALIASES;
+    let agg_aliases = <T as RegisteredAggregateUdf>::ALIASES;
+
+    if const_slice_eq(basic_aliases, agg_aliases) {
+        return;
+    }
+
+    let mut msg_buf = [0u8; 512];
+    let mut curs = 0;
+
+    curs += const_write_all!(msg_buf, [NAME_MSG, "`alias` arguments; got [",], 0);
+
+    let mut i = 0;
+    while i < basic_aliases.len() {
+        if i > 0 {
+            curs += const_write_all!(msg_buf, [", "], curs);
+        }
+        curs += const_write_all!(msg_buf, ["`", basic_aliases[i], "`",], curs);
+        i += 1;
+    }
+
+    curs += const_write_all!(msg_buf, ["] and ["], curs);
+
+    let mut i = 0;
+    while i < agg_aliases.len() {
+        if i > 0 {
+            curs += const_write_all!(msg_buf, [", "], curs);
+        }
+        curs += const_write_all!(msg_buf, ["`", agg_aliases[i], "`",], curs);
+        i += 1;
+    }
+
+    curs += const_write_all!(msg_buf, ["]"], curs);
+
+    let msg = const_slice_to_str(msg_buf.as_slice(), curs);
+    panic!("{}", msg);
+}
 
 #[cfg(test)]
 mod tests;

--- a/udf/src/wrapper/const_helpers.rs
+++ b/udf/src/wrapper/const_helpers.rs
@@ -1,0 +1,127 @@
+use std::str;
+
+/// Similar to `copy_from_slice` but works at comptime.
+///
+/// Takes a `start` offset so we can index into an existing slice.
+macro_rules! const_arr_copy {
+    ($dst:expr, $src:expr, $start:expr) => {{
+        let max_idx = $dst.len() - $start;
+        let (to_write, add_ellipsis) = if $src.len() <= (max_idx.saturating_sub($start)) {
+            ($src.len(), false)
+        } else {
+            ($src.len().saturating_sub(4), true)
+        };
+
+        let mut i = 0;
+        while i < to_write {
+            $dst[i + $start] = $src[i];
+            i += 1;
+        }
+
+        if add_ellipsis {
+            while i < $dst.len() - $start {
+                $dst[i + $start] = b'.';
+                i += 1;
+            }
+        }
+
+        i
+    }};
+}
+
+macro_rules! const_write_all {
+    ($dst:expr, $src_arr:expr, $start:expr) => {{
+        let mut offset = $start;
+
+        let mut i = 0;
+        while i < $src_arr.len() && offset < $dst.len() {
+            offset += const_arr_copy!($dst, $src_arr[i].as_bytes(), offset);
+            i += 1;
+        }
+
+        offset - $start
+    }};
+}
+
+pub const fn const_str_eq(a: &str, b: &str) -> bool {
+    let a = a.as_bytes();
+    let b = b.as_bytes();
+    if a.len() != b.len() {
+        return false;
+    }
+
+    let mut i = 0;
+    while i < a.len() {
+        if a[i] != b[i] {
+            return false;
+        }
+
+        i += 1;
+    }
+
+    true
+}
+
+pub const fn const_slice_eq(a: &[&str], b: &[&str]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+
+    let mut i = 0;
+    while i < a.len() {
+        if !const_str_eq(a[i], b[i]) {
+            return false;
+        }
+
+        i += 1;
+    }
+
+    true
+}
+
+pub const fn const_slice_to_str(s: &[u8], len: usize) -> &str {
+    assert!(len <= s.len());
+    // FIXME(msrv): use const `split_at` once our MSRV gets to 1.71
+    // SAFETY: validated inbounds above
+    let buf = unsafe { std::slice::from_raw_parts(s.as_ptr(), len) };
+
+    match str::from_utf8(buf) {
+        Ok(v) => v,
+        Err(_e) => panic!("utf8 error"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_arr_copy() {
+        let mut x = [0u8; 20];
+        let w1 = const_arr_copy!(x, b"foobar", 0);
+        let s = const_slice_to_str(x.as_slice(), w1);
+        assert_eq!(s, "foobar");
+
+        let w2 = const_arr_copy!(x, b"foobar", w1);
+        let s = const_slice_to_str(x.as_slice(), w1 + w2);
+        assert_eq!(s, "foobarfoobar");
+
+        let mut x = [0u8; 6];
+        let written = const_arr_copy!(x, b"foobar", 0);
+        let s = const_slice_to_str(x.as_slice(), written);
+        assert_eq!(s, "foobar");
+
+        let mut x = [0u8; 5];
+        let written = const_arr_copy!(x, b"foobar", 0);
+        let s = const_slice_to_str(x.as_slice(), written);
+        assert_eq!(s, "fo...");
+    }
+
+    #[test]
+    fn test_const_write_all() {
+        let mut x = [0u8; 20];
+        let w1 = const_write_all!(x, ["foo", "bar", "baz"], 0);
+        let s = const_slice_to_str(x.as_slice(), w1);
+        assert_eq!(s, "foobarbaz");
+    }
+}

--- a/udf/src/wrapper/tests.rs
+++ b/udf/src/wrapper/tests.rs
@@ -159,3 +159,58 @@ fn test_wrapper_bufwrapper() {
         wrap_init::<ExampleBufOpt, _>(todo!(), todo!(), todo!());
     }
 }
+
+#[test]
+fn test_verify_aggregate_attributes() {
+    struct Foo;
+    impl RegisteredBasicUdf for Foo {
+        const NAME: &'static str = "foo";
+        const ALIASES: &'static [&'static str] = &["foo", "bar"];
+        const DEFAULT_NAME_USED: bool = false;
+    }
+    impl RegisteredAggregateUdf for Foo {
+        const NAME: &'static str = "foo";
+        const ALIASES: &'static [&'static str] = &["foo", "bar"];
+        const DEFAULT_NAME_USED: bool = false;
+    }
+
+    verify_aggregate_attributes::<Foo>();
+}
+
+#[test]
+#[should_panic = "#[register]` on `BasicUdf` and `AggregateUdf` must have the same `name` \
+                  argument; got `foo` and `bar`"]
+fn test_verify_aggregate_attributes_mismatch_name() {
+    struct Foo;
+    impl RegisteredBasicUdf for Foo {
+        const NAME: &'static str = "foo";
+        const ALIASES: &'static [&'static str] = &["foo", "bar"];
+        const DEFAULT_NAME_USED: bool = false;
+    }
+    impl RegisteredAggregateUdf for Foo {
+        const NAME: &'static str = "bar";
+        const ALIASES: &'static [&'static str] = &["foo", "bar"];
+        const DEFAULT_NAME_USED: bool = false;
+    }
+
+    verify_aggregate_attributes::<Foo>();
+}
+
+#[test]
+#[should_panic = "`#[register]` on `BasicUdf` and `AggregateUdf` must have the same `alias` \
+                  arguments; got [`foo`, `bar`, `baz`] and [`foo`, `bar`]"]
+fn test_verify_aggregate_attributes_mismatch_aliases() {
+    struct Foo;
+    impl RegisteredBasicUdf for Foo {
+        const NAME: &'static str = "foo";
+        const ALIASES: &'static [&'static str] = &["foo", "bar", "baz"];
+        const DEFAULT_NAME_USED: bool = false;
+    }
+    impl RegisteredAggregateUdf for Foo {
+        const NAME: &'static str = "foo";
+        const ALIASES: &'static [&'static str] = &["foo", "bar"];
+        const DEFAULT_NAME_USED: bool = false;
+    }
+
+    verify_aggregate_attributes::<Foo>();
+}


### PR DESCRIPTION
Add better validation that `name = ...` and `alias = ...` line up when
there is a mismatch between the `BasicUdf` and `AggregateUdf`
implementation, and fix a problem that was disallowing use of aliases in
aggregate UDFs.

Error messages are significantly improved.

Fixes <https://github.com/pluots/sql-udf/issues/59>